### PR TITLE
Security jackson-databind

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -3,8 +3,6 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <packaging>pom</packaging>
-
     <parent>
         <groupId>net.kemitix</groupId>
         <artifactId>kemitix-parent</artifactId>
@@ -15,9 +13,28 @@
     <groupId>com.hubio</groupId>
     <artifactId>s3sftp-parent</artifactId>
     <version>DEV-SNAPSHOT</version>
+    <packaging>pom</packaging>
 
     <name>S3 SFTP Server (parent)</name>
     <description>SFTP Server to access an Amazon S3 Bucket</description>
+
+    <properties>
+        <tiles-maven-plugin.version>2.11</tiles-maven-plugin.version>
+        <kemitix-tiles.version>0.9.0</kemitix-tiles.version>
+        <kemitix-checkstyle.version>4.1.1</kemitix-checkstyle.version>
+        <spring-boot.version>1.5.14.RELEASE</spring-boot.version>
+        <apache-sshd.version>1.3.0</apache-sshd.version>
+        <map-builder.version>1.0.0</map-builder.version>
+        <bouncycastle.version>1.60</bouncycastle.version>
+        <junit-hierarchicalcontextrunner.version>4.12.1</junit-hierarchicalcontextrunner.version>
+        <mockito-java8.version>0.3.1</mockito-java8.version>
+        <digraph-dependency.basePackage>com.hubio.s3sftp</digraph-dependency.basePackage>
+        <s3fs.version>2.2.2</s3fs.version>
+        <assertj.version>3.10.0</assertj.version>
+        <lombok.version>1.18.0</lombok.version>
+        <aws-java-sdk.version>1.11.375</aws-java-sdk.version>
+        <guava.version>25.1-jre</guava.version>
+    </properties>
 
     <inceptionYear>2017</inceptionYear>
 
@@ -41,23 +58,6 @@
             <organizationUrl>https://hubio.com/</organizationUrl>
         </developer>
     </developers>
-
-    <properties>
-        <tiles-maven-plugin.version>2.11</tiles-maven-plugin.version>
-        <kemitix-tiles.version>0.9.0</kemitix-tiles.version>
-        <kemitix-checkstyle.version>4.1.1</kemitix-checkstyle.version>
-        <spring-boot.version>1.5.14.RELEASE</spring-boot.version>
-        <digraph-dependency.basePackage>com.hubio.s3sftp</digraph-dependency.basePackage>
-        <apache-sshd.version>1.3.0</apache-sshd.version>
-        <map-builder.version>1.0.0</map-builder.version>
-        <bouncycastle.version>1.54</bouncycastle.version>
-        <s3fs.version>2.2.2</s3fs.version>
-        <assertj.version>3.10.0</assertj.version>
-        <junit-hierarchicalcontextrunner.version>4.12.1</junit-hierarchicalcontextrunner.version>
-        <mockito-java8.version>0.3.1</mockito-java8.version>
-        <lombok.version>1.18.0</lombok.version>
-        <aws-java-sdk.version>1.11.375</aws-java-sdk.version>
-    </properties>
 
     <build>
         <plugins>
@@ -118,14 +118,12 @@
                 <!-- The Bouncy Castle Java API for handling the OpenPGP protocol. -->
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcpg-jdk15on</artifactId>
-                <!--<optional>true</optional>-->
                 <version>${bouncycastle.version}</version>
             </dependency>
             <dependency>
                 <!-- The Bouncy Castle Java APIs for CMS, PKCS, EAC, TSP, CMP, CRMF, OCSP, and certificate generation. -->
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcpkix-jdk15on</artifactId>
-                <!--<optional>true</optional>-->
                 <version>${bouncycastle.version}</version>
             </dependency>
             <dependency>
@@ -135,8 +133,16 @@
                 <version>${bouncycastle.version}</version>
             </dependency>
             <!-- S3 Filesystem -->
+            <dependency><!-- override version from s3fs to avoid security flaw -->
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+            </dependency>
+            <dependency><!-- override version from s3fs to avoid security flaw -->
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-s3</artifactId>
+                <version>${aws-java-sdk.version}</version>
+            </dependency>
             <dependency>
-                <!-- S3 filesystem provider for Java 7. -->
                 <groupId>com.upplication</groupId>
                 <artifactId>s3fs</artifactId>
                 <version>${s3fs.version}</version>
@@ -147,19 +153,16 @@
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
                 <version>${assertj.version}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>de.bechte.junit</groupId>
                 <artifactId>junit-hierarchicalcontextrunner</artifactId>
                 <version>${junit-hierarchicalcontextrunner.version}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>info.solidsoft.mockito</groupId>
                 <artifactId>mockito-java8</artifactId>
                 <version>${mockito-java8.version}</version>
-                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -34,6 +34,7 @@
         <lombok.version>1.18.0</lombok.version>
         <aws-java-sdk.version>1.11.375</aws-java-sdk.version>
         <guava.version>25.1-jre</guava.version>
+        <jackson-databind.version>2.9.6</jackson-databind.version>
     </properties>
 
     <inceptionYear>2017</inceptionYear>
@@ -136,6 +137,12 @@
             <dependency><!-- override version from s3fs to avoid security flaw -->
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
+            </dependency>
+            <dependency><!-- override version from aws-java-sdk to avoid security flaw -->
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson-databind.version}</version>
             </dependency>
             <dependency><!-- override version from s3fs to avoid security flaw -->
                 <groupId>com.amazonaws</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -14,17 +14,9 @@
     <name>S3 SFTP Server (server)</name>
 
     <properties>
-        <spring-boot.version>1.5.14.RELEASE</spring-boot.version>
-        <apache-sshd.version>1.3.0</apache-sshd.version>
-        <map-builder.version>1.0.0</map-builder.version>
-        <bouncycastle.version>1.60</bouncycastle.version>
-        <junit-hierarchicalcontextrunner.version>4.12.1</junit-hierarchicalcontextrunner.version>
-        <mockito-java8.version>0.3.1</mockito-java8.version>
-
         <jacoco-class-line-covered-ratio>0</jacoco-class-line-covered-ratio>
         <jacoco-class-instruction-covered-ratio>0</jacoco-class-instruction-covered-ratio>
         <jacoco-class-missed-count-maximum>0</jacoco-class-missed-count-maximum>
-        <guava.version>25.1-jre</guava.version>
     </properties>
 
     <dependencies>
@@ -36,49 +28,33 @@
         <dependency>
             <groupId>org.apache.sshd</groupId>
             <artifactId>sshd-core</artifactId>
-            <version>${apache-sshd.version}</version>
         </dependency>
         <dependency>
             <groupId>me.andrz</groupId>
             <artifactId>map-builder</artifactId>
-            <version>${map-builder.version}</version>
         </dependency>
         <dependency> <!-- Encryption (Bouncy Castle) -->
             <!-- The Bouncy Castle Java API for handling the OpenPGP protocol. -->
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpg-jdk15on</artifactId>
-            <version>${bouncycastle.version}</version>
             <!--<optional>true</optional>-->
         </dependency>
         <dependency>
             <!-- The Bouncy Castle Java APIs for CMS, PKCS, EAC, TSP, CMP, CRMF, OCSP, and certificate generation. -->
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
-            <version>${bouncycastle.version}</version>
             <!--<optional>true</optional>-->
         </dependency>
         <dependency>
             <!-- The Bouncy Castle Crypto package is a Java implementation of cryptographic algorithms.  -->
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>${bouncycastle.version}</version>
         </dependency>
         <!-- S3 Filesystem -->
-        <dependency><!-- override version from s3fs to avoid security flaw -->
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
-        </dependency>
-        <dependency><!-- override version from s3fs to avoid security flaw -->
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-s3</artifactId>
-            <version>${aws-java-sdk.version}</version>
-        </dependency>
         <dependency>
             <!-- S3 filesystem provider for Java 7. -->
             <groupId>com.upplication</groupId>
             <artifactId>s3fs</artifactId>
-            <version>${s3fs.version}</version>
         </dependency>
 
         <!-- Unit Testing -->
@@ -92,19 +68,16 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>de.bechte.junit</groupId>
             <artifactId>junit-hierarchicalcontextrunner</artifactId>
-            <version>${junit-hierarchicalcontextrunner.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>info.solidsoft.mockito</groupId>
             <artifactId>mockito-java8</artifactId>
-            <version>${mockito-java8.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
* normalise dependencies and properties
* `jackson-databind` 2.6.7.1 has a security flaw
    https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-32111

**N.B.** The current `aws-java-sdk` is not compatible with the updated `jackson-databind`. This PR can't be merged until an update is released and integrated.