### PR TITLE
Fix #46 Password Authentication

### DIFF
--- a/server/src/main/java/com/hubio/s3sftp/server/PasswordAuthenticationProvider.java
+++ b/server/src/main/java/com/hubio/s3sftp/server/PasswordAuthenticationProvider.java
@@ -24,6 +24,7 @@
 package com.hubio.s3sftp.server;
 
 import lombok.val;
+import org.apache.sshd.server.auth.password.PasswordAuthenticator;
 import org.apache.sshd.server.session.ServerSession;
 
 import java.util.Objects;
@@ -36,7 +37,7 @@ import java.util.Objects;
  *
  * @author Paul Campbell (paul.campbell@hubio.com)
  */
-public interface PasswordAuthenticationProvider extends AuthenticationProvider {
+public interface PasswordAuthenticationProvider extends AuthenticationProvider, PasswordAuthenticator {
 
     /**
      * Authenticate the username and password for the session.

--- a/server/src/test/java/com/hubio/s3sftp/server/DefaultS3SftpServerTest.java
+++ b/server/src/test/java/com/hubio/s3sftp/server/DefaultS3SftpServerTest.java
@@ -265,9 +265,9 @@ class DefaultS3SftpServerTest implements WithAssertions {
     }
 
     @Test
-    void whenConfigureAuthenticateionWithPasswordThenAddPasswordFactoryInstance() {
+    void whenConfigureAuthenticationWithPasswordThenAddPasswordFactoryInstance() {
         //given
-        val authenticationProvider = mock(MyPasswordAuthenticator.class);
+        val authenticationProvider = S3SftpServer.simpleAuthenticator(users);
         val configuration = new S3SftpServerConfiguration(
                 2000, "hka", "hkp", new File("hkfp"),
                 authenticationProvider, sessionBucket, sessionHome, SftpSession::getUsername, "uri");


### PR DESCRIPTION
`PasswordAuthenticationProvider` was missing the `PasswordAuthenticator`
interface.

Fixes #46