### PR TITLE
[jenkins] Don't use verify profile for 'clean verify' builds

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -68,7 +68,7 @@ pipeline {
             when { expression { dependenciesSupportJDK >= 9 } }
             steps {
                 withMaven(maven: 'maven', jdk: 'JDK 9') {
-                    sh "${mvn} clean --activate-profiles verify verify -Djava.version=9"
+                    sh "${mvn} clean verify -Djava.version=9"
                 }
             }
         }
@@ -76,7 +76,7 @@ pipeline {
             when { expression { dependenciesSupportJDK >= 10 } }
             steps {
                 withMaven(maven: 'maven', jdk: 'JDK 10') {
-                    sh "${mvn} clean --activate-profiles verify verify -Djava.version=10"
+                    sh "${mvn} clean verify -Djava.version=10"
                 }
             }
         }


### PR DESCRIPTION
The verify profile prevents compilation, while the clean phase erased the
compiled classes.