### PR TITLE
Bump Apache Tika from 1.5 to 1.19.1

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -63,6 +63,7 @@
         <guava.version>27.0.1-jre</guava.version>
         <mon.version>2.0.0</mon.version>
         <jackson-databind.version>2.9.7</jackson-databind.version>
+	<tika.version>1.19.1</tika.version>
     </properties>
 
     <build>
@@ -152,6 +153,11 @@
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
                 <version>${jackson-databind.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tika</groupId>
+                <artifactId>tika-core</artifactId>
+                <version>${tika.version}</version>
             </dependency>
             <!-- S3 Filesystem -->
             <dependency>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -65,6 +65,10 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
         </dependency>
+        <dependency><!-- override version from s3fs to avoid security flaw -->
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-core</artifactId>
+        </dependency>
         <dependency>
             <!-- S3 filesystem provider for Java 7. -->
             <groupId>com.upplication</groupId>


### PR DESCRIPTION
Apache Tika is a transitive dependency from Upplication's s3fs.
Unfortunately the version it depends on, 1.5, has a security
vulnerability. There has been no sign the Upplication are interested
in merging security fixes.

This overrides the version used by Upplication's s3fs.